### PR TITLE
Support showing "popups" in an iframe

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,6 +24,7 @@ const bridge = new Messaging();
   * @property {string} [bridgeUrl] Override wallet.myalgo.com default frame url.
   * @property {number} [timeout] Number of msec to wait the popup response, default value: 1600000 msec.
   * @property {boolean} [disableLedgerNano] It will disable ledger nano accounts and returns only mnemonic accounts.
+  * @property {HTMLIFrameElement} [iframe] Render "popups" in this iframe rather than a new window
   */
 
 /**
@@ -248,6 +249,12 @@ class MyAlgoConnect {
 		 * @type {boolean}
 		 */
 		this.disableLedgerNano = (options && options.disableLedgerNano) ? options.disableLedgerNano : false;
+
+		/**
+		 * @access private
+		 * @type {HTMLIFrameElement}
+		 */
+		 this.iframe = options.iframe;
 	}
 
 	/**
@@ -269,7 +276,12 @@ class MyAlgoConnect {
 		}
 
 		try {
-			this.currentConnectPopup = openPopup(this.url + "/connect.html");
+			if(this.iframe) {
+				this.iframe.src = this.url + "/connect.html"
+				this.currentConnectPopup = this.iframe.contentWindow
+			} else {
+				this.currentConnectPopup = openPopup(this.url + "/connect.html");
+			}
 
 			await this.waitForWindowToLoad(this.currentConnectPopup);
 
@@ -321,7 +333,12 @@ class MyAlgoConnect {
 			txn = prepareTxn(transaction);
 
 		try {
-			this.currentSigntxPopup = openPopup(this.url + "/signtx.html");
+			if(this.iframe) {
+				this.iframe.src = this.url + "/signtx.html"
+				this.currentSigntxPopup = this.iframe.contentWindow
+			} else {
+				this.currentSigntxPopup = openPopup(this.url + "/signtx.html");
+			}
 
 			await this.waitForWindowToLoad(this.currentSigntxPopup);
 
@@ -380,7 +397,13 @@ class MyAlgoConnect {
 		}
 
 		try {
-			this.currentSignLogicSigPopup = openPopup(this.url + "/logicsigtx.html");
+			if(this.iframe) {
+				this.iframe.src = this.url + "/logicsigtx.html"
+				this.currentSignLogicSigPopup = this.iframe.contentWindow
+			} else {
+				this.currentSignLogicSigPopup = openPopup(this.url + "/logicsigtx.html");
+			}
+
 			await this.waitForWindowToLoad(this.currentSignLogicSigPopup);
 
 			// Send program
@@ -439,7 +462,9 @@ class MyAlgoConnect {
 	 * @returns {void}
 	 */
 	closeWindow(window) {
-		if (window && !window.closed && window.close) {
+		if (this.iframe) {
+			this.iframe.src = ''
+		} else if (window && !window.closed && window.close) {
 			window.close();
 		}
 	}


### PR DESCRIPTION
This PR adds an additional option to the `MyAlgoConnect` constructor that allows an iframe to optionally be defined for rendering the "popups" in. 

I understand browsers are moving in a direction that would make this unusable due to cross-origin security/privacy features, but using an iframe is necessary in some edge cases, such as an environment where popups are strictly forbidden (for example, Chrome Embedded Framework applications). 

This is an optional feature with minimal changes to the code-base. Functionality was tested for all three popups and they all work as one would expect. 