### PR TITLE
Sign Transaction option: override signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # MyAlgo Connect Change log
 
-## [1.1.2] - 10-01-2022
+## [1.1.3] - 2022-04-13
+
+### Added
+
+ - Added optional object parameter to the `signTransaction` method to force MyAlgoConnect to sign with a specific account
+
+### Fixed
+
+ - Fixed error caused by undefined `window` reference when working with server side applications/frameworks such as Next.js (see related [issue](https://github.com/randlabs/communication-bridge/issues/5))
+
+### Known issue
+
+- MyAlgo Connect package still has the `Buffer is not defined` error (#27).
+
+## [1.1.2] - 2022-01-10
 
 ### Added
 
@@ -16,7 +30,7 @@
 
 - MyAlgo Connect package still has the `Buffer is not defined` error (#27).
 
-## [1.1.1] - 01-09-2021
+## [1.1.1] - 2021-09-01
 
 ### Added
 
@@ -27,7 +41,7 @@
 
 - MyAlgo Connect package still has the `Buffer is not defined` error (#27).
 
-## [1.1.0] - 13-07-2021
+## [1.1.0] - 2021-07-13
 
 ### Added
 
@@ -63,13 +77,13 @@
 
 - MyAlgo Connect package still has the `Buffer is not defined` error (#27).
 
-## [1.0.1] - 08-03-2021
+## [1.0.1] - 2021-03-08
 
 ### Fixes
 
 - Exported SignedTxn (#14).
 - Minor fixes
 
-## [1.0.0] - 04-03-2021
+## [1.0.0] - 2021-03-04
 
 - Initial release.

--- a/index.d.ts
+++ b/index.d.ts
@@ -158,6 +158,10 @@ export interface Options {
 	disableLedgerNano?: boolean;
 }
 
+export interface SignTransactionOptions {
+	overrideSigner?: Address;
+}
+
 export interface ConnectionSettings {
 	shouldSelectOneAccount?: boolean;
 	openManager?: boolean;
@@ -182,17 +186,19 @@ export default class MyAlgoConnect {
 	 * @async
 	 * @description Sign an Algorand Transaction.
 	 * @param transaction Expect a valid Algorand transaction
+	 * @param signOptions Sign transactions options object.
 	 * @returns Returns signed transaction
 	 */
-	signTransaction(transaction: AlgorandTxn | EncodedTransaction): Promise<SignedTx>;
+	signTransaction(transaction: AlgorandTxn | EncodedTransaction, signOptions?: SignTransactionOptions): Promise<SignedTx>;
 
 	/**
 	 * @async
 	 * @description Sign an Algorand Transaction.
 	 * @param transaction Expect a valid Algorand transaction array.
+	 * @param signOptions Sign transactions options object.
 	 * @returns Returns signed an array of signed transactions.
 	 */
-	signTransaction(transaction: (AlgorandTxn | EncodedTransaction)[]): Promise<SignedTx[]>;
+	signTransaction(transaction: (AlgorandTxn | EncodedTransaction)[], signOptions?: SignTransactionOptions): Promise<SignedTx[]>;
 
 	/**
 	 * @async

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,11 @@ const { sleep, prepareTxn } = require("./utils/utils");
 const Errors = require("./utils/errors");
 
 const Messaging = require("./messaging/Messaging");
-const bridge = new Messaging();
+
+/**
+ * @type {Messaging | null}
+ */
+let bridge = null;
 
 /**
  * @description Transaction hash
@@ -199,6 +203,10 @@ class MyAlgoConnect {
 	 * @param {Options} [options] Operation options
 	 */
 	constructor(options) {
+
+		if (!bridge) {
+			bridge = new Messaging();
+		}
 
 		/**
 		 * @access private

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,6 +27,13 @@ const bridge = new Messaging();
   */
 
 /**
+  * @description Sign transaction options
+  * @typedef SignTransactionOptions
+  * @type {object}
+  * @property {Address} [overrideSigner] Force transactions to be signed with the specified account instead of the from/auth address.
+  */
+
+/**
  * @description Connect method settings
  * @typedef ConnectionSettings
  * @type {object}
@@ -299,11 +306,12 @@ class MyAlgoConnect {
 	 * @access public
 	 * @description Open a new window to sign transaction.
 	 * @param {Transaction|Transaction[]|EncodedTransaction|EncodedTransaction[]} transaction Transaction object or a Transaction array.
+	 * @param {SignTransactionOptions} [signOptions] Sign transactions options object.
 	 * (The signer account must be the same for all transactions).
 	 * @returns {(SignedTx|SignedTx[])} Returns transaction blob or an Array of blobs, depends if the
 	 * transaction was an object or an array.
 	 */
-	async signTransaction(transaction) {
+	async signTransaction(transaction, signOptions) {
 		let txn;
 
 		if (this.currentSigntxPopup) {
@@ -329,7 +337,7 @@ class MyAlgoConnect {
 			const res = await this.bridge.sendMessage(
 				this.currentSigntxPopup, {
 					method: "transaction",
-					params: { txn, settings: { disableLedgerNano: this.disableLedgerNano } }
+					params: { txn, settings: { disableLedgerNano: this.disableLedgerNano }, options: signOptions },
 				},
 				this.url, this.options
 			);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Allow the client to specify options for transaction signing operations.

The new option, `overrideSigner`, allows the client to force a specific address to act as signer for all transactions, regardless of the `sender` address.