### PR TITLE
Move bridge initialization to MAC constructor

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,11 @@ const { sleep, prepareTxn } = require("./utils/utils");
 const Errors = require("./utils/errors");
 
 const Messaging = require("./messaging/Messaging");
-const bridge = new Messaging();
+
+/**
+ * @type {Messaging | null}
+ */
+let bridge = null;
 
 /**
  * @description Transaction hash
@@ -192,6 +196,10 @@ class MyAlgoConnect {
 	 * @param {Options} [options] Operation options
 	 */
 	constructor(options) {
+
+		if (!bridge) {
+			bridge = new Messaging();
+		}
 
 		/**
 		 * @access private

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Initialize bridge inside MyAlgoConnect constructor in order to prevent errors caused while trying to set up event listeners due to `window` not being defined.

Related to: [randlabs/communication-bridge/issues/5](https://github.com/randlabs/communication-bridge/issues/5)