### PR TITLE
Add tealSign method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MyAlgo Connect Change log
 
+## [1.2.0] - 2022-XX-XX
+
+### Added
+
+ - Added new function `tealSign` to generate `ed25519` signatures that can be verified by a teal program. See also: [ed25519verify opcode](https://developer.algorand.org/docs/get-details/dapps/avm/teal/opcodes/#ed25519verify) and [algosdk.tealSign](https://algorand.github.io/js-algorand-sdk/modules.html#tealSign)
+
 ## [1.1.3] - 2022-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MyAlgo Connect Change log
 
-## [1.2.0] - 2022-XX-XX
+## [1.2.0] - 2022-06-02
 
 ### Added
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,4 +208,14 @@ export default class MyAlgoConnect {
 	 * @returns Returns signed teal
 	 */
 	signLogicSig(logic: Uint8Array | Base64, address: Address): Promise<Uint8Array>;
+
+	/**
+	 * @async
+	 * @description Creates a signature the data that can later be verified by the contract through the ed25519verify opcode
+	 * @param data Arbitrary data to sign
+	 * @param contractAddress Contract address/TEAL program hash
+	 * @param address Signer Address
+	 * @returns Returns the data signature
+	 */
+	tealSign(data: Uint8Array | Base64, contractAddress: Address, address: Address): Promise<Uint8Array>;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -252,6 +252,13 @@ class MyAlgoConnect {
 
 		/**
 		 * @access private
+		 * @description This is used to reuse the current tealsign opened popup
+		 * @type {Window|null}
+		 */
+		this.currentTealSignPopup = null;
+
+		/**
+		 * @access private
 		 * @description Replace default bridge options
 		 * @type {import("@randlabs/communication-bridge").sendMessageOptions}
 		 */
@@ -420,6 +427,56 @@ class MyAlgoConnect {
 		catch (err) {
 			this.closeWindow(this.currentSignLogicSigPopup);
 			this.currentSignLogicSigPopup = null;
+			throw err;
+		}
+	}
+
+	/**
+	 * @async
+	 * @access public
+	 * @description Open a new window to sign data to verify in a teal program.
+	 * @param {Uint8Array|Base64} data Data to sign
+	 * @param {Address} contractAddress Address of the contract that will verify the data
+	 * @param {Address} address Signer Address
+	 * @returns {Uint8Array} Returns data signature
+	 */
+	async tealSign(data, contractAddress, address) {
+
+		if (this.currentTealSignPopup) {
+			if (this.currentTealSignPopup.closed) {
+				this.currentTealSignPopup = null;
+			}
+			else {
+				this.focusWindow(this.currentTealSignPopup);
+			}
+		}
+
+		try {
+			this.currentTealSignPopup = openPopup(this.url + "/tealsign.html");
+			await this.waitForWindowToLoad(this.currentTealSignPopup);
+
+			// Send program
+			let dataInBase64 = data;
+			if (data.constructor === Uint8Array)
+				dataInBase64 = Buffer.from(data).toString("base64");
+
+			const res = await this.bridge.sendMessage(
+				this.currentTealSignPopup,
+				{ method: "tealsign", params: { data: dataInBase64, contractAddress: contractAddress, address } },
+				this.url, this.options
+			);
+
+			this.closeWindow(this.currentTealSignPopup);
+			this.currentTealSignPopup = null;
+
+			if (res.status === "error")
+				throw new Error(res.message);
+
+			return new Uint8Array(Buffer.from(res.data.signature, "base64"));
+		}
+		catch (err) {
+			this.closeWindow(this.currentTealSignPopup);
+			this.currentTealSignPopup = null;
 			throw err;
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Add `tealSign` method to sign an arbitrary array of bytes to later be verified by a contract through an opcode.

See also: [ed25519verify opcode](https://developer.algorand.org/docs/get-details/dapps/avm/teal/opcodes/#ed25519verify) and [algosdk.tealSign](https://algorand.github.io/js-algorand-sdk/modules.html#tealSign)