### PR TITLE
Add signBytes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # MyAlgo Connect Change log
 
+## [1.3.0] - 2022-08-24
+
+### Added
+
+ - Added new function `signBytes` to sign an arbitrary array of bytes. See also: [algosdk.signBytes](https://algorand.github.io/js-algorand-sdk/modules.html#signBytes). This operation is only supported for mnemonic accounts.
+
 ## [1.2.0] - 2022-06-02
 
 ### Added
 
- - Added new function `tealSign` to generate `ed25519` signatures that can be verified by a teal program. See also: [ed25519verify opcode](https://developer.algorand.org/docs/get-details/dapps/avm/teal/opcodes/#ed25519verify) and [algosdk.tealSign](https://algorand.github.io/js-algorand-sdk/modules.html#tealSign)
+ - Added new function `tealSign` to generate `ed25519` signatures that can be verified by a teal program. See also: [ed25519verify opcode](https://developer.algorand.org/docs/get-details/dapps/avm/teal/opcodes/#ed25519verify) and [algosdk.tealSign](https://algorand.github.io/js-algorand-sdk/modules.html#tealSign). This operation is only supported for mnemonic accounts.
 
 ## [1.1.3] - 2022-04-13
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -218,4 +218,13 @@ export default class MyAlgoConnect {
 	 * @returns Returns the data signature
 	 */
 	tealSign(data: Uint8Array | Base64, contractAddress: Address, address: Address): Promise<Uint8Array>;
+
+	/**
+	 * @async
+	 * @description Sign an arbitrary array of bytes
+	 * @param bytes Bytes to sign
+	 * @param address Signer Address
+	 * @returns Returns bytes signature
+	 */
+	signBytes(bytes: Uint8Array, address: Address): Promise<Uint8Array>;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -259,6 +259,13 @@ class MyAlgoConnect {
 
 		/**
 		 * @access private
+		 * @description This is used to reuse the current signbytes opened popup
+		 * @type {Window|null}
+		 */
+		 this.currentSignBytesPopup = null;
+
+		/**
+		 * @access private
 		 * @description Replace default bridge options
 		 * @type {import("@randlabs/communication-bridge").sendMessageOptions}
 		 */
@@ -477,6 +484,51 @@ class MyAlgoConnect {
 		catch (err) {
 			this.closeWindow(this.currentTealSignPopup);
 			this.currentTealSignPopup = null;
+			throw err;
+		}
+	}
+
+	/**
+	 * @async
+	 * @access public
+	 * @description Open a new window to sign an arbitrary array of bytes.
+	 * @param {Uint8Array} bytes Bytes to sign
+	 * @param {Address} address Signer Address
+	 * @returns {Uint8Array} Returns bytes signature
+	 */
+	 async signBytes(bytes, address) {
+		if (this.currentSignBytesPopup) {
+			if (this.currentSignBytesPopup.closed) {
+				this.currentSignBytesPopup = null;
+			}
+			else {
+				this.focusWindow(this.currentSignBytesPopup);
+			}
+		}
+
+		try {
+			this.currentSignBytesPopup = openPopup(this.url + "/signbytes.html");
+			await this.waitForWindowToLoad(this.currentSignBytesPopup);
+
+			let messageInBase64 = Buffer.from(bytes).toString("base64");
+
+			const res = await this.bridge.sendMessage(
+				this.currentSignBytesPopup,
+				{ method: "signbytes", params: { data: messageInBase64, address } },
+				this.url, this.options
+			);
+
+			this.closeWindow(this.currentSignBytesPopup);
+			this.currentSignBytesPopup = null;
+
+			if (res.status === "error")
+				throw new Error(res.message);
+
+			return new Uint8Array(Buffer.from(res.data.signature, "base64"));
+		}
+		catch (err) {
+			this.closeWindow(this.currentSignBytesPopup);
+			this.currentSignBytesPopup = null;
 			throw err;
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Add a `signBytes` method, which ultimately calls the same name algosdk function (see [docs](https://algorand.github.io/js-algorand-sdk/modules.html#signBytes)). This operation is only supported for mnemonic accounts.