### PR TITLE
Implement ARC-0001 base interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -158,28 +158,28 @@ export interface WalletTransaction {
 	txn: TxnStr;
 
 	// [Not Supported] Optional authorized address used to sign the transaction when the account is rekeyed
-	// authAddr?: Address;
+	authAddr?: Address;
 
 	// [Not Supported] Multisig metadata used to sign the transaction
-	// msig?: MultisigMetadata;
+	msig?: MultisigMetadata;
 
 	// Optional list of addresses that must sign the transactions
 	signers?: Address[];
 
 	// [Not Supported] Optional base64 encoding of the canonical msgpack encoding of a  SignedTxn corresponding to txn, when signers=[]
-	// stxn?: SignedTxnStr;
+	stxn?: SignedTxnStr;
 
 	// [Not Supported] Optional message explaining the reason of the transaction
-	// message?: string;
+	message?: string;
 
 	// [Not Supported] Optional message explaining the reason of this group of transaction.
 	// Field only allowed in the first transaction of a group
-	// groupMessage?: string;
+	groupMessage?: string;
 }
 
 export interface SignTxnsOpts {
 	// [Not Supported] Optional message explaining the reason of the group of transactions
-	// message?: string;
+	message?: string;
 }
 
 export interface SignTxnsError extends Error {

--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,52 @@ export type EncodedTransaction = Base64 | Uint8Array;
 
 export type AlgorandTxn = PaymentTxn | AssetTxn | AssetConfigTxn | AssetCreateTxn | DestroyAssetTxn | FreezeAssetTxn | KeyRegTxn | ApplTxn;
 
+export type TxnStr = Base64;
+export type SignedTxnStr = Base64;
+
+export interface MultisigMetadata {
+	// Multisig version
+	version: number;
+
+	// Multisig threshold value
+	threshold: number;
+
+	// Multisig Cosigners
+	addrs: Address[];
+}
+
+export interface WalletTransaction {
+	// Base64 encoding of the canonical msgpack encoding of a Transaction
+	txn: TxnStr;
+
+	// Optional authorized address used to sign the transaction when the account is rekeyed
+	authAddr?: Address;
+
+	// Multisig metadata used to sign the transaction
+	msig?: MultisigMetadata;
+
+	// Optional list of addresses that must sign the transactions
+	signers?: Address[];
+
+	// Optional base64 encoding of the canonical msgpack encoding of a  SignedTxn corresponding to txn, when signers=[]
+	stxn?: SignedTxnStr;
+
+	// Optional message explaining the reason of the transaction
+	message?: string;
+
+	// Optional message explaining the reason of this group of transaction. Field only allowed in the first transaction of a group
+	groupMessage?: string;
+}
+
+export interface SignTxnsOpts {
+	// Optional message explaining the reason of the group of transactions
+	message?: string;
+}
+
+export interface SignTxnsError extends Error {
+	code: number;
+	data?: any;
+}
 
 export interface SignedTx {
 	// Transaction hash
@@ -199,6 +245,15 @@ export default class MyAlgoConnect {
 	 * @returns Returns signed an array of signed transactions.
 	 */
 	signTransaction(transaction: (AlgorandTxn | EncodedTransaction)[], signOptions?: SignTransactionOptions): Promise<SignedTx[]>;
+
+	/**
+	 * @async
+	 * @description Sign a set of transactions.
+	 * @param txns A non-empty list of WalletTransaction objects.
+	 * @param signOptions Sign transactions options object.
+	 * @returns Returns an array of base64 encoding of the signed transaction, or null where the transaction was not to be signed
+	 */
+	signTxns(txns: WalletTransaction[], opts?: SignTxnsOpts): Promise<(SignedTxnStr | null)[]>;
 
 	/**
 	 * @async

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,28 +157,29 @@ export interface WalletTransaction {
 	// Base64 encoding of the canonical msgpack encoding of a Transaction
 	txn: TxnStr;
 
-	// Optional authorized address used to sign the transaction when the account is rekeyed
-	authAddr?: Address;
+	// [Not Supported] Optional authorized address used to sign the transaction when the account is rekeyed
+	// authAddr?: Address;
 
-	// Multisig metadata used to sign the transaction
-	msig?: MultisigMetadata;
+	// [Not Supported] Multisig metadata used to sign the transaction
+	// msig?: MultisigMetadata;
 
 	// Optional list of addresses that must sign the transactions
 	signers?: Address[];
 
-	// Optional base64 encoding of the canonical msgpack encoding of a  SignedTxn corresponding to txn, when signers=[]
-	stxn?: SignedTxnStr;
+	// [Not Supported] Optional base64 encoding of the canonical msgpack encoding of a  SignedTxn corresponding to txn, when signers=[]
+	// stxn?: SignedTxnStr;
 
-	// Optional message explaining the reason of the transaction
-	message?: string;
+	// [Not Supported] Optional message explaining the reason of the transaction
+	// message?: string;
 
-	// Optional message explaining the reason of this group of transaction. Field only allowed in the first transaction of a group
-	groupMessage?: string;
+	// [Not Supported] Optional message explaining the reason of this group of transaction.
+	// Field only allowed in the first transaction of a group
+	// groupMessage?: string;
 }
 
 export interface SignTxnsOpts {
-	// Optional message explaining the reason of the group of transactions
-	message?: string;
+	// [Not Supported] Optional message explaining the reason of the group of transactions
+	// message?: string;
 }
 
 export interface SignTxnsError extends Error {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 const { openPopup } = require("./popup/popup");
 const { sleep, prepareTxn } = require("./utils/utils");
-const Errors = require("./utils/errors");
+const { Errors, SignTxnsError } = require("./utils/errors");
 
 const Messaging = require("./messaging/Messaging");
 
@@ -185,6 +185,37 @@ let bridge = null;
  */
 
 /**
+ * @description Base64 encoding of the canonical msgpack encoding of a SignedTxn
+ * @typedef SignedTxnStr
+ * @type {Base64}
+ */
+
+/**
+ * @description Application call transaction object
+ * @typedef MultisigMetadata
+ * @type {object}
+ * @property {number} version Multisig version
+ * @property {number} threshold Multisig threshold value
+ * @property {Address[]} addrs Multisig cosigners
+ */
+
+/**
+ * @description ARC-0001 Transaction Object
+ * @typedef WalletTransactions
+ * @type {object}
+ * @property {txs}
+ * @property {Base64} txn Base64 encoding of the canonical msgpack encoding of a Transaction.
+ * @property {Address} [authAddr] AlgorandAddress Authorized address used to sign the transaction when the account is rekeyed
+ * @property {MultisigMetadata} [msig] MultisigMetadata Multisig metadata used to sign the transaction
+ * @property {Address[]} [signers] AlgorandAddress[] Optional list of addresses that must sign the transactions
+ * @property {SignedTxnStr} [stxn] SignedTxnStr Base64 encoding of the canonical msgpack encoding
+ * of a SignedTxn corresponding to txn, when signers=[]
+ * @property {string} [message] string Optional message explaining the reason of the transaction
+ * @property {string} [groupMessage] string Message explaining the reason of this group of transaction.
+ * Field only allowed in the first transaction of a group
+ */
+
+/**
  * @typedef EncodedTransaction
  * @type {Uint8Array|Base64} Algorand Encoded Transaction
  */
@@ -326,6 +357,7 @@ class MyAlgoConnect {
 	/**
 	 * @async
 	 * @access public
+	 * @deprecated
 	 * @description Open a new window to sign transaction.
 	 * @param {Transaction|Transaction[]|EncodedTransaction|EncodedTransaction[]} transaction Transaction object or a Transaction array.
 	 * @param {SignTransactionOptions} [signOptions] Sign transactions options object.
@@ -382,6 +414,58 @@ class MyAlgoConnect {
 			res.data.blob = new Uint8Array(Buffer.from(res.data.blob, "hex"));
 
 			return res.data;
+		}
+		catch (err) {
+			this.closeWindow(this.currentSigntxPopup);
+			this.currentSigntxPopup = null;
+			throw err;
+		}
+	}
+
+	/**
+	 * @async
+	 * @access public
+	 * @description Open a new window to sign transaction.
+	 * @param {WalletTransaction[]} txnsToSign Transactions to sign.
+	 * @param {SignTxnsOpts} [opts] Sign transactions options object.
+	 * @returns {(SignedTxnStr|null)[]} Returns an array of base64 encoding of the SignedTxn,
+	 * or null where the transaction was not to be signed.
+	 */
+	async signTxns(txnsToSign, opts) {
+		if (this.currentSigntxPopup) {
+			if (this.currentSigntxPopup.closed) {
+				this.currentSigntxPopup = null;
+			}
+			else {
+				this.focusWindow(this.currentSigntxPopup);
+			}
+		}
+
+		try {
+			let txns = txnsToSign;
+			if (!Array.isArray(txnsToSign)) {
+				txns = [ txnsToSign ];
+			}
+
+			this.currentSigntxPopup = openPopup(this.url + "/signtx.html");
+			await this.waitForWindowToLoad(this.currentSigntxPopup);
+
+			// Send transaction info
+			const res = await this.bridge.sendMessage(
+				this.currentSigntxPopup, {
+					method: "signTxns",
+					params: { txns, settings: { disableLedgerNano: this.disableLedgerNano }, opts },
+				},
+				this.url, this.options
+			);
+
+			this.closeWindow(this.currentSigntxPopup);
+			this.currentSigntxPopup = null;
+
+			if (res.status === "error")
+				throw new SignTxnsError(res.message, res.code, res.data);
+
+			return res.data.map(r => (r ? Buffer.from(r.blob, 'hex').toString('base64') : null));
 		}
 		catch (err) {
 			this.closeWindow(this.currentSigntxPopup);

--- a/lib/main.js
+++ b/lib/main.js
@@ -205,7 +205,7 @@ let bridge = null;
  * @type {object}
  * @property {txs}
  * @property {Base64} txn Base64 encoding of the canonical msgpack encoding of a Transaction.
- * @property {Address[]} [signers] AlgorandAddress[] Optional list of addresses that must sign the transactions
+ * @property {Address[]} [signers] Optional list of addresses that must sign the transactions
  */
 
 /**

--- a/lib/main.js
+++ b/lib/main.js
@@ -205,7 +205,14 @@ let bridge = null;
  * @type {object}
  * @property {txs}
  * @property {Base64} txn Base64 encoding of the canonical msgpack encoding of a Transaction.
+ * @property {Address} [authAddr] Authorized address used to sign the transaction when the account is rekeyed
+ * @property {MultisigMetadata} [msig] Multisig metadata used to sign the transaction
  * @property {Address[]} [signers] Optional list of addresses that must sign the transactions
+ * @property {SignedTxnStr} [stxn] Base64 encoding of the canonical msgpack encoding
+ * of a SignedTxn corresponding to txn, when signers=[]
+ * @property {string} [message] Optional message explaining the reason of the transaction
+ * @property {string} [groupMessage] Message explaining the reason of this group of transaction.
+ * Field only allowed in the first transaction of a group
  */
 
 /**

--- a/lib/main.js
+++ b/lib/main.js
@@ -205,14 +205,13 @@ let bridge = null;
  * @type {object}
  * @property {txs}
  * @property {Base64} txn Base64 encoding of the canonical msgpack encoding of a Transaction.
- * @property {Address} [authAddr] AlgorandAddress Authorized address used to sign the transaction when the account is rekeyed
- * @property {MultisigMetadata} [msig] MultisigMetadata Multisig metadata used to sign the transaction
  * @property {Address[]} [signers] AlgorandAddress[] Optional list of addresses that must sign the transactions
- * @property {SignedTxnStr} [stxn] SignedTxnStr Base64 encoding of the canonical msgpack encoding
- * of a SignedTxn corresponding to txn, when signers=[]
- * @property {string} [message] string Optional message explaining the reason of the transaction
- * @property {string} [groupMessage] string Message explaining the reason of this group of transaction.
- * Field only allowed in the first transaction of a group
+ */
+
+/**
+ * @description ARC-0001 Transaction Options Object
+ * @typedef SignTxnsOpts
+ * @type {object}
  */
 
 /**

--- a/lib/main.js
+++ b/lib/main.js
@@ -356,7 +356,6 @@ class MyAlgoConnect {
 	/**
 	 * @async
 	 * @access public
-	 * @deprecated
 	 * @description Open a new window to sign transaction.
 	 * @param {Transaction|Transaction[]|EncodedTransaction|EncodedTransaction[]} transaction Transaction object or a Transaction array.
 	 * @param {SignTransactionOptions} [signOptions] Sign transactions options object.

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -1,6 +1,19 @@
-module.exports = {
+const ERRORS = {
 	WINDOW_NOT_LOADED: "Window not loaded",
 	WINDOW_IS_OPENED: "Windows is opened",
 	WINDOW_NOT_OPENED: "Can not open popup window",
 	INVALID_WINDOW: "Invalid window",
+};
+
+class SignTxnsError extends Error {
+	constructor(message, code, data) {
+		super(message);
+		this.code = code;
+		this.data = data;
+	}
+}
+
+module.exports = {
+	ERRORS,
+	SignTxnsError
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@randlabs/myalgo-connect",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Implement [ARC-0001](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0001.md) basic interface.

Fields/settings not yet supported: `authAddr`, `msig`, `stxn`, `message`, `groupMessage`. These will be implemented down the road.

This new method does not replace the previous signature function `signTransaction`.